### PR TITLE
Add isDependent flag

### DIFF
--- a/edge.coffee
+++ b/edge.coffee
@@ -3,6 +3,7 @@ deviceTypesCommon = require 'resin-device-types/common'
 
 module.exports =
 	slug: 'edge'
+	isDependent: true
 	name: 'Edge Device Builder'
 	arch: 'amd64'
 	state: 'released'


### PR DESCRIPTION
Connects to #3

The UI needs to separately handle the dependent device types and hide them from the drop-down.
Right now this is the only such type. I'd prefer this to be a flag rather than relying on the specific slug in the UI.